### PR TITLE
Regex match and not escape

### DIFF
--- a/src/WinRPM.jl
+++ b/src/WinRPM.jl
@@ -458,7 +458,7 @@ function do_install(package::Package)
         error("failed to download $name $(data[2]) from $source/$path.")
     end
     cache = getcachedir(source)
-    path2 = joinpath(cache,escape(path))
+    path2 = joinpath(cache, match(r"[^/]+$",path).match)
     open(path2, "w") do f
         write(f, data[1])
     end


### PR DESCRIPTION
I had trouble with `escape` butchering a folderpath into a filename. I found that using a simple regex match to pick off the filename solved my problems. Don't know if other people might have had this issue as well. I'm on Windows 7 and Julia v0.7.